### PR TITLE
FEM- auto play doesn't works after change media, when first media with empty Ad tag and second with Ad

### DIFF
--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -581,6 +581,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
 
     @Override
     public void destroyAdsManager() {
+        isAdRequested = false;
         if (adsManager == null) {
             return;
         }
@@ -589,7 +590,6 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         contentCompleted();
         adsManager.destroy();
         adsManager = null;
-        isAdRequested = false;
         isAdDisplayed = false;
         adPlaybackCancelled = false;
     }


### PR DESCRIPTION
reset isAdRequested flag was not called in this case