### PR TITLE
toJsonObject() is deprecated.

### DIFF
--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAConfig.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAConfig.java
@@ -260,6 +260,12 @@ public class IMAConfig {
 //    }
 //
 
+    /**
+     * Due to Views required for setControlsOverlayList()
+     *
+     * @deprecated pass only object instead no need to convert to json object.
+     */
+    @Deprecated
     public JsonObject toJSONObject() {
         JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty(AD_TAG_LANGUAGE_KEY , language);

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAConfig.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAConfig.java
@@ -263,7 +263,7 @@ public class IMAConfig {
     /**
      * Due to Views required for setControlsOverlayList()
      *
-     * @deprecated pass only object instead no need to convert to json object.
+     * @deprecated pass only IMAConfig object to the plugin instead of JsonObject.
      */
     @Deprecated
     public JsonObject toJSONObject() {


### PR DESCRIPTION
- Due to OMID overlay views, deprecating the method.
- No need to convert the object to json, instead object can be passed.