### PR TITLE
FEM-2429 Use only one player instance during ad or content playback 

### DIFF
--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAConfig.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAConfig.java
@@ -71,9 +71,6 @@ public class IMAConfig {
     private List<String> videoMimeTypes;
     private transient List<View> controlsOverlayList;
 
-    // For lower end devices, don't prepare the content player when the Ad starts instead play it when content_resume_requested is called.
-    private boolean releasePlayersForLowerEndDevices;
-
     //private Map<Double,String> tagsTimes; // <AdTime,URL_to_execute>
 
     //View companionView;
@@ -94,7 +91,6 @@ public class IMAConfig {
         this.adTagResponse                          = null;
         this.playerType                             = AD_PLAYER_TYPE;
         this.playerVersion                          = AD_PLAYER_VERSION;
-        this.releasePlayersForLowerEndDevices   = false; // No need to release content player unless app sets this boolean to True
 
         //if (tagTimes == null) {
         //    tagTimes = new HashMap<>();
@@ -265,15 +261,6 @@ public class IMAConfig {
         if (controlsOverlay != null) {
             this.controlsOverlayList.add(controlsOverlay);
         }
-        return this;
-    }
-
-    public boolean isReleasePlayersForLowerEndDevices() {
-        return releasePlayersForLowerEndDevices;
-    }
-
-    public IMAConfig setReleasePlayersForLowerEndDevices(boolean releasePlayersForLowerEndDevices) {
-        this.releasePlayersForLowerEndDevices = releasePlayersForLowerEndDevices;
         return this;
     }
 

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAConfig.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAConfig.java
@@ -71,26 +71,30 @@ public class IMAConfig {
     private List<String> videoMimeTypes;
     private transient List<View> controlsOverlayList;
 
+    // For lower end devices, don't prepare the content player when the Ad starts instead play it when content_resume_requested is called.
+    private boolean releaseContentPlayerIsRequiredForAds;
+
     //private Map<Double,String> tagsTimes; // <AdTime,URL_to_execute>
 
     //View companionView;
 
     public IMAConfig() {
-        this.language                 = "en";
-        this.adTagType = AdTagType.VAST;
-        this.enableBackgroundPlayback = false;
-        this.videoBitrate             = -1;
-        this.adAttribution            = true;
-        this.adCountDown              = true;
-        this.adLoadTimeOut            = DEFAULT_AD_LOAD_TIMEOUT;
-        this.enableDebugMode          = false;
-        this.alwaysStartWithPreroll   = false;
-        this.videoMimeTypes           = new ArrayList<>();
+        this.language                               = "en";
+        this.adTagType                              = AdTagType.VAST;
+        this.enableBackgroundPlayback               = false;
+        this.videoBitrate                           = -1;
+        this.adAttribution                          = true;
+        this.adCountDown                            = true;
+        this.adLoadTimeOut                          = DEFAULT_AD_LOAD_TIMEOUT;
+        this.enableDebugMode                        = false;
+        this.alwaysStartWithPreroll                 = false;
+        this.videoMimeTypes                         = new ArrayList<>();
         this.videoMimeTypes.add(PKMediaFormat.mp4.mimeType);
-        this.adTagURL = null;         //=> must be set via setter
-        this.adTagResponse = null;
-        this.playerType                = AD_PLAYER_TYPE;
-        this.playerVersion             = AD_PLAYER_VERSION;
+        this.adTagURL                               = null;         //=> must be set via setter
+        this.adTagResponse                          = null;
+        this.playerType                             = AD_PLAYER_TYPE;
+        this.playerVersion                          = AD_PLAYER_VERSION;
+        this.releaseContentPlayerIsRequiredForAds   = false; // No need to release content player unless app sets this boolean to True
 
         //if (tagTimes == null) {
         //    tagTimes = new HashMap<>();
@@ -261,6 +265,15 @@ public class IMAConfig {
         if (controlsOverlay != null) {
             this.controlsOverlayList.add(controlsOverlay);
         }
+        return this;
+    }
+
+    public boolean isReleaseContentPlayerIsRequiredForAds() {
+        return releaseContentPlayerIsRequiredForAds;
+    }
+
+    public IMAConfig setReleaseContentPlayerIsRequiredForAds(boolean releaseContentPlayerIsRequiredForAds) {
+        this.releaseContentPlayerIsRequiredForAds = releaseContentPlayerIsRequiredForAds;
         return this;
     }
 

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAConfig.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAConfig.java
@@ -72,7 +72,7 @@ public class IMAConfig {
     private transient List<View> controlsOverlayList;
 
     // For lower end devices, don't prepare the content player when the Ad starts instead play it when content_resume_requested is called.
-    private boolean releaseContentPlayerIsRequiredForAds;
+    private boolean releasePlayersForLowerEndDevices;
 
     //private Map<Double,String> tagsTimes; // <AdTime,URL_to_execute>
 
@@ -94,7 +94,7 @@ public class IMAConfig {
         this.adTagResponse                          = null;
         this.playerType                             = AD_PLAYER_TYPE;
         this.playerVersion                          = AD_PLAYER_VERSION;
-        this.releaseContentPlayerIsRequiredForAds   = false; // No need to release content player unless app sets this boolean to True
+        this.releasePlayersForLowerEndDevices   = false; // No need to release content player unless app sets this boolean to True
 
         //if (tagTimes == null) {
         //    tagTimes = new HashMap<>();
@@ -268,12 +268,12 @@ public class IMAConfig {
         return this;
     }
 
-    public boolean isReleaseContentPlayerIsRequiredForAds() {
-        return releaseContentPlayerIsRequiredForAds;
+    public boolean isReleasePlayersForLowerEndDevices() {
+        return releasePlayersForLowerEndDevices;
     }
 
-    public IMAConfig setReleaseContentPlayerIsRequiredForAds(boolean releaseContentPlayerIsRequiredForAds) {
-        this.releaseContentPlayerIsRequiredForAds = releaseContentPlayerIsRequiredForAds;
+    public IMAConfig setReleasePlayersForLowerEndDevices(boolean releasePlayersForLowerEndDevices) {
+        this.releasePlayersForLowerEndDevices = releasePlayersForLowerEndDevices;
         return this;
     }
 

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -488,7 +488,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     }
 
     private boolean isReleaseContentPlayerRequired() {
-        return player.getSettings() instanceof PlayerSettings && ((PlayerSettings) player.getSettings()).isSetPrepareAfterAd();
+        return player.getSettings() instanceof PlayerSettings && ((PlayerSettings) player.getSettings()).isContentPrepareAfterAdsPrepare();
     }
 
     private void clearAdLoadingInBackground() {

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -1145,7 +1145,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 }
                 adPlaybackCancelled = false;
 
-                log.d("CONTENT_RESUME_REQUESTED isReleaseContentPlayerRequired = " + isReleaseContentPlayerRequired + " videoPlayerWithAdPlayback = " + videoPlayerWithAdPlayback);
+                log.d("CONTENT_RESUME_REQUESTED isReleaseContentPlayerRequired = " + isReleaseContentPlayerRequired);
 
                 if (isReleaseContentPlayerRequired) {
                     displayContent();

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -1024,6 +1024,10 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
             log.i("EventData: " + adEvent.getAdData().toString());
         }
 
+        if (adConfig != null) {
+            log.i("isReleasePlayersForLowerEndDevices: " + adConfig.isReleasePlayersForLowerEndDevices());
+        }
+
         switch (adEvent.getType()) {
             case LOADED:
                 adInfo = createAdInfo(adEvent.getAd());

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -775,8 +775,8 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
 
     @Override
     public void removeAdProviderListener() {
-        log.d("removeAdProviderListener");
         if (adConfig != null && !isReleaseContentPlayerRequired) {
+            log.d("removeAdProviderListener");
             pkAdProviderListener = null;
         }
     }

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -179,6 +179,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         player.getView().addView(videoPlayerWithAdPlayback.getExoPlayerView());
         this.context = context;
         this.messageBus = messageBus;
+        this.player.setReleasePlayersForLowerEndDevices(adConfig.isReleasePlayersForLowerEndDevices());
         addListeners(player);
     }
 
@@ -761,7 +762,11 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
 
     @Override
     public void removeAdProviderListener() {
-        pkAdProviderListener = null;
+        log.d("removeAdProviderListener");
+        if (adConfig != null && !adConfig.isReleasePlayersForLowerEndDevices()) {
+            log.d("adConfig.isReleasePlayersForLowerEndDevices() = " + adConfig.isReleasePlayersForLowerEndDevices());
+            pkAdProviderListener = null;
+        }
     }
 
     @Override
@@ -965,6 +970,11 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                     public void onEvent(PlayerEvent.DurationChanged event) {
                         log.d("IMA DURATION_CHANGE received calling play");
                         if (player != null && player.getView() != null && !IMAPlugin.this.isAdDisplayed()) {
+
+                            if (adConfig.isReleasePlayersForLowerEndDevices() && player.getDuration() > 0) {
+                                player.onApplicationResumed();
+                            }
+
                             IMAPlugin.this.displayContent();
                             if (IMAPlugin.this.getPlayerEngine() != null) {
                                 IMAPlugin.this.getPlayerEngine().play();
@@ -1056,7 +1066,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                     displayAd();
                 }
 
-                if (adConfig.isReleaseContentPlayerIsRequiredForAds() && player != null && player.getCurrentPosition() > 0) {
+                if (adConfig.isReleasePlayersForLowerEndDevices() && player != null && player.getDuration() > 0) {
                     player.onApplicationPaused();
                 }
 
@@ -1118,12 +1128,13 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 }
                 adPlaybackCancelled = false;
 
-                if (adConfig.isReleaseContentPlayerIsRequiredForAds()) {
+                if (adConfig.isReleasePlayersForLowerEndDevices()) {
+                    displayContent();
                     player.onApplicationResumed();
                     player.play();
                 }
 
-                if (adConfig.isReleaseContentPlayerIsRequiredForAds() && videoPlayerWithAdPlayback != null) {
+                if (adConfig.isReleasePlayersForLowerEndDevices() && videoPlayerWithAdPlayback != null) {
                     videoPlayerWithAdPlayback.stop();
                 }
 
@@ -1157,7 +1168,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                     return;
                 }
 
-                if (!adConfig.isReleaseContentPlayerIsRequiredForAds()) {
+                if (!adConfig.isReleasePlayersForLowerEndDevices()) {
                     preparePlayer(false);
                 }
 

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -767,7 +767,6 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     public void removeAdProviderListener() {
         log.d("removeAdProviderListener");
         if (adConfig != null && !isReleaseContentPlayerRequired()) {
-            log.d("adConfig.isReleasePlayersForLowerEndDevices() = " + isReleaseContentPlayerRequired());
             pkAdProviderListener = null;
         }
     }
@@ -1026,10 +1025,6 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
 
         if (adEvent.getAdData() != null) {
             log.i("EventData: " + adEvent.getAdData().toString());
-        }
-
-        if (isReleaseContentPlayerRequired()) {
-            log.i("onAdEvent isReleasePlayersForLowerEndDevices: " + isReleaseContentPlayerRequired());
         }
 
         switch (adEvent.getType()) {

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -489,8 +489,12 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         return player.getSettings() instanceof PlayerSettings && ((PlayerSettings) player.getSettings()).isAdAutoPlayOnResume();
     }
 
+    /**
+     * Function to check if content player is not required during the AD playback
+     * once the AD finishes then only content player is prepared
+     */
     private boolean isReleaseContentPlayerRequired() {
-        return player.getSettings() instanceof PlayerSettings && ((PlayerSettings) player.getSettings()).isContentPrepareAfterAdsPrepare();
+        return player.getSettings() instanceof PlayerSettings && ((PlayerSettings) player.getSettings()).isUseSinglePlayerInstance();
     }
 
     private void clearAdLoadingInBackground() {

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -107,9 +107,6 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     private AdsLoader adsLoader;
     private AdsLoader.AdsLoadedListener adsLoadedListener;
 
-    // For lower end devices, don't prepare the content player when the Ad starts instead play it when content_resume_requested is called.
-    private boolean releaseContentPlayerIsRequiredForAds = true;
-
     private ImaSdkSettings imaSdkSettings;
     private AdsRenderingSettings renderingSettings;
     private AdCuePoints adTagCuePoints;
@@ -1059,7 +1056,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                     displayAd();
                 }
 
-                if (releaseContentPlayerIsRequiredForAds && player != null && player.getCurrentPosition() > 0) {
+                if (adConfig.isReleaseContentPlayerIsRequiredForAds() && player != null && player.getCurrentPosition() > 0) {
                     player.onApplicationPaused();
                 }
 
@@ -1121,12 +1118,12 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 }
                 adPlaybackCancelled = false;
 
-                if (releaseContentPlayerIsRequiredForAds) {
+                if (adConfig.isReleaseContentPlayerIsRequiredForAds()) {
                     player.onApplicationResumed();
                     player.play();
                 }
 
-                if (releaseContentPlayerIsRequiredForAds && videoPlayerWithAdPlayback != null) {
+                if (adConfig.isReleaseContentPlayerIsRequiredForAds() && videoPlayerWithAdPlayback != null) {
                     videoPlayerWithAdPlayback.stop();
                 }
 
@@ -1160,7 +1157,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                     return;
                 }
 
-                if (!releaseContentPlayerIsRequiredForAds) {
+                if (!adConfig.isReleaseContentPlayerIsRequiredForAds()) {
                     preparePlayer(false);
                 }
 

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -119,6 +119,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     private boolean adPlaybackCancelled;
     private boolean appIsInBackground;
     private boolean isContentEndedBeforeMidroll;
+    private boolean isReleaseContentPlayerRequired;
 
     private boolean isContentPrepared;
     private boolean isAutoPlay;
@@ -163,6 +164,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     protected void onLoad(final Player player, Object config, final MessageBus messageBus, Context context) {
         log.d("onLoad");
         this.player = player;
+
         if (player == null) {
             log.e("Error, player instance is null.");
             return;
@@ -187,7 +189,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
             log.d("Received:PlayerEvent:" + event.eventType().name() + " lastAdEventReceived = " + lastAdEventReceived);
             AdCuePoints adCuePoints = new AdCuePoints(getAdCuePointsList());
             adCuePoints.setAdPluginName(IMAPlugin.factory.getName());
-            if (!isContentPrepared && !isReleaseContentPlayerRequired()) {
+            if (!isContentPrepared && !isReleaseContentPlayerRequired) {
                 log.d("Event: ENDED ignored content is not prepared");
                 return;
             }
@@ -241,6 +243,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     protected void onUpdateMedia(PKMediaConfig mediaConfig) {
         log.d("Start onUpdateMedia");
         this.mediaConfig = mediaConfig;
+
         if (mediaConfig != null) {
             playbackStartPosition = mediaConfig.getStartPosition();
             log.d("mediaConfig start pos = " + playbackStartPosition);
@@ -773,7 +776,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     @Override
     public void removeAdProviderListener() {
         log.d("removeAdProviderListener");
-        if (adConfig != null && !isReleaseContentPlayerRequired()) {
+        if (adConfig != null && !isReleaseContentPlayerRequired) {
             pkAdProviderListener = null;
         }
     }
@@ -980,8 +983,8 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                         log.d("IMA DURATION_CHANGE received calling play");
                         if (player != null && player.getView() != null && !IMAPlugin.this.isAdDisplayed()) {
 
-                            log.d("In IMA prepare player onEvent isReleaseContentPlayerRequired = " + isReleaseContentPlayerRequired());
-                            if (isReleaseContentPlayerRequired() && player.getDuration() > 0) {
+                            log.d("In IMA prepare player onEvent isReleaseContentPlayerRequired = " + isReleaseContentPlayerRequired);
+                            if (isReleaseContentPlayerRequired && player.getDuration() > 0) {
                                 player.onApplicationResumed();
                             }
 
@@ -1017,6 +1020,8 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
             log.w("WARNING, adsManager == null");
             return;
         }
+
+        isReleaseContentPlayerRequired = isReleaseContentPlayerRequired();
 
         if(adEventsMap == null){
             log.e("ERROR, adEventsMap == null");
@@ -1076,8 +1081,9 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                     displayAd();
                 }
 
-                log.d("CONTENT_PAUSE_REQUESTED isReleaseContentPlayerRequired = " + isReleaseContentPlayerRequired());
-                if (isReleaseContentPlayerRequired() && player != null && player.getDuration() > 0) {
+                log.d("CONTENT_PAUSE_REQUESTED isReleaseContentPlayerRequired = " + isReleaseContentPlayerRequired);
+
+                if (isReleaseContentPlayerRequired && player != null && player.getDuration() > 0) {
                     player.onApplicationPaused();
                 }
 
@@ -1139,15 +1145,15 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 }
                 adPlaybackCancelled = false;
 
-                log.d("CONTENT_RESUME_REQUESTED isReleaseContentPlayerRequired = " + isReleaseContentPlayerRequired() + " videoPlayerWithAdPlayback = " + videoPlayerWithAdPlayback);
+                log.d("CONTENT_RESUME_REQUESTED isReleaseContentPlayerRequired = " + isReleaseContentPlayerRequired + " videoPlayerWithAdPlayback = " + videoPlayerWithAdPlayback);
 
-                if (isReleaseContentPlayerRequired()) {
+                if (isReleaseContentPlayerRequired) {
                     displayContent();
                     player.onApplicationResumed();
                     player.play();
                 }
 
-                if (isReleaseContentPlayerRequired() && videoPlayerWithAdPlayback != null) {
+                if (isReleaseContentPlayerRequired && videoPlayerWithAdPlayback != null) {
                     videoPlayerWithAdPlayback.stop();
                 }
 
@@ -1181,9 +1187,9 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                     return;
                 }
 
-                log.d("STARTED isReleaseContentPlayerRequired = " + isReleaseContentPlayerRequired());
+                log.d("STARTED isReleaseContentPlayerRequired = " + isReleaseContentPlayerRequired);
 
-                if (!isReleaseContentPlayerRequired()) {
+                if (!isReleaseContentPlayerRequired) {
                     preparePlayer(false);
                 }
 

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -187,7 +187,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
             log.d("Received:PlayerEvent:" + event.eventType().name() + " lastAdEventReceived = " + lastAdEventReceived);
             AdCuePoints adCuePoints = new AdCuePoints(getAdCuePointsList());
             adCuePoints.setAdPluginName(IMAPlugin.factory.getName());
-            if (!isContentPrepared) {
+            if (!isContentPrepared && !isReleaseContentPlayerRequired()) {
                 log.d("Event: ENDED ignored content is not prepared");
                 return;
             }


### PR DESCRIPTION
- For lower end devices, do not prepare the content player when adEvent `STARTED` is fired.
- Application can set the function `setReleasePlayersForLowerEndDevices` while configuring the IMAConfig. By default this is false.
