### PR TITLE
FEM-2656 - IMA DAI Cannot play post roll ad after pausing it

### DIFF
--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIPlugin.java
@@ -952,7 +952,7 @@ public class IMADAIPlugin extends PKPlugin implements com.google.ads.interactive
     public boolean isAllAdsCompleted() {
         if (pluginCuePoints != null && !pluginCuePoints.isEmpty()) {
             CuePoint cuePoint = pluginCuePoints.get(pluginCuePoints.size() -1);
-            return cuePoint.isPlayed();
+            return cuePoint.isPlayed() && !isAdDisplayed;
         }
         return false;
     }


### PR DESCRIPTION
IMA DAI will sign the ad played once started so it is incorrect to use this logic only for all ads completed decision now also will ask if ad displayed at time we assume all ads completed