### PR TITLE
FEM-2708 IMA sdk stuck in pod ad 

### DIFF
--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/ExoPlayerWithAdPlayback.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/ExoPlayerWithAdPlayback.java
@@ -470,11 +470,11 @@ public class ExoPlayerWithAdPlayback extends RelativeLayout implements PlaybackP
         }
     }
 
-    public void stop() {
+    public void stop(boolean isPlayerReset) {
         isPlayerReady = false;
         if (adVideoPlayerView != null && adVideoPlayerView.getPlayer() != null) {
             adVideoPlayerView.getPlayer().setPlayWhenReady(false);
-            adVideoPlayerView.getPlayer().stop(true);
+            adVideoPlayerView.getPlayer().stop(isPlayerReset);
         }
     }
 
@@ -600,7 +600,7 @@ public class ExoPlayerWithAdPlayback extends RelativeLayout implements PlaybackP
         if (isAppInBackground) {
             lastKnownAdPosition = getAdPosition();
             if (deviceRequiresDecoderRelease()) {
-                stop();
+                stop(true);
             } else {
                 pause();
             }

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/ExoPlayerWithAdPlayback.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/ExoPlayerWithAdPlayback.java
@@ -470,11 +470,11 @@ public class ExoPlayerWithAdPlayback extends RelativeLayout implements PlaybackP
         }
     }
 
-    public void stop(boolean isPlayerReset) {
+    public void stop(boolean isResetRequired) {
         isPlayerReady = false;
         if (adVideoPlayerView != null && adVideoPlayerView.getPlayer() != null) {
             adVideoPlayerView.getPlayer().setPlayWhenReady(false);
-            adVideoPlayerView.getPlayer().stop(isPlayerReset);
+            adVideoPlayerView.getPlayer().stop(isResetRequired);
         }
     }
 

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -715,7 +715,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         }
         log.d("IMA Start destroyAdsManager");
         if (videoPlayerWithAdPlayback != null) {
-            videoPlayerWithAdPlayback.stop();
+            videoPlayerWithAdPlayback.stop(true);
         }
         adsManager.destroy();
         contentCompleted();
@@ -1168,8 +1168,8 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 log.d("AD REQUEST AD_CONTENT_RESUME_REQUESTED");
                 
                 // Added due to an Async call coming from IMA ad player which send buffer start and end events
-                if (videoPlayerWithAdPlayback != null) {
-                    videoPlayerWithAdPlayback.stop();
+                if (adsManager != null) {
+                    videoPlayerWithAdPlayback.stop(false);
                 }
 
                 if (checkIfDiscardAdRequired()) {
@@ -1238,7 +1238,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 }
 
                 if (isReleaseContentPlayerRequired && videoPlayerWithAdPlayback != null) {
-                    videoPlayerWithAdPlayback.stop();
+                    videoPlayerWithAdPlayback.stop(true);
                 }
 
                 break;

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -1166,6 +1166,12 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 break;
             case CONTENT_RESUME_REQUESTED:
                 log.d("AD REQUEST AD_CONTENT_RESUME_REQUESTED");
+                
+                // Added due to an Async call coming from IMA ad player which send buffer start and end events
+                if (videoPlayerWithAdPlayback != null) {
+                    videoPlayerWithAdPlayback.stop();
+                }
+
                 if (checkIfDiscardAdRequired()) {
                     for (Long cuePoint : adTagCuePoints.getAdCuePoints()) {
                         if (cuePoint != 0 && cuePoint != -1 && ((cuePoint / Consts.MILLISECONDS_MULTIPLIER_FLOAT) < playbackStartPosition)) {
@@ -1443,6 +1449,10 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
 
     @Override
     public void onBufferStart() {
+        if (lastAdEventReceived == AdEvent.Type.CONTENT_RESUME_REQUESTED) {
+            return;
+        }
+
         isAdDisplayed = true;
         if (lastAdEventReceived == AdEvent.Type.AD_BUFFER_START) {
             return;
@@ -1455,6 +1465,10 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
 
     @Override
     public void onBufferEnd() {
+        if (lastAdEventReceived == AdEvent.Type.CONTENT_RESUME_REQUESTED) {
+            return;
+        }
+
         isAdDisplayed = true;
         if (lastAdEventReceived == AdEvent.Type.AD_BUFFER_END) {
             return;

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -15,7 +15,6 @@ package com.kaltura.playkit.plugins.ima;
 import android.content.Context;
 import android.os.CountDownTimer;
 import android.os.Handler;
-
 import android.text.TextUtils;
 import android.view.View;
 import android.view.ViewGroup;
@@ -45,17 +44,14 @@ import com.kaltura.playkit.PKMediaConfig;
 import com.kaltura.playkit.PKMediaFormat;
 import com.kaltura.playkit.PKPlugin;
 import com.kaltura.playkit.Player;
-
 import com.kaltura.playkit.PlayerEngineWrapper;
 import com.kaltura.playkit.PlayerEvent;
-
 import com.kaltura.playkit.ads.AdTagType;
 import com.kaltura.playkit.ads.AdsPlayerEngineWrapper;
 import com.kaltura.playkit.ads.PKAdErrorType;
 import com.kaltura.playkit.ads.PKAdInfo;
 import com.kaltura.playkit.ads.PKAdPluginType;
 import com.kaltura.playkit.ads.PKAdProviderListener;
-
 import com.kaltura.playkit.player.PlayerEngine;
 import com.kaltura.playkit.player.PlayerSettings;
 import com.kaltura.playkit.plugin.ima.BuildConfig;
@@ -1166,16 +1162,12 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 break;
             case CONTENT_RESUME_REQUESTED:
                 log.d("AD REQUEST AD_CONTENT_RESUME_REQUESTED");
-                
-                // Added due to an Async call coming from IMA ad player which send buffer start and end events
-                if (adsManager != null) {
-                    videoPlayerWithAdPlayback.stop(false);
-                }
 
                 if (checkIfDiscardAdRequired()) {
                     for (Long cuePoint : adTagCuePoints.getAdCuePoints()) {
                         if (cuePoint != 0 && cuePoint != -1 && ((cuePoint / Consts.MILLISECONDS_MULTIPLIER_FLOAT) < playbackStartPosition)) {
                             log.d("discardAdBreak");
+                            // Discards current ad break and resumes content. If there is no current ad then the next ad break is discarded.
                             adsManager.discardAdBreak();
                             playbackStartPosition = null; // making sure it will nu be done again.
                             break;
@@ -1358,7 +1350,10 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                         log.d("LOG Error but continue to next ad in pod");
                         return;
                     } else {
-                        adsManager.discardAdBreak();
+                        isAdRequested = false;
+                        if (videoPlayerWithAdPlayback != null) {
+                            videoPlayerWithAdPlayback.stop(false);
+                        }
                     }
                 }
                 String error = "Non-fatal Error";

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -1162,7 +1162,6 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 break;
             case CONTENT_RESUME_REQUESTED:
                 log.d("AD REQUEST AD_CONTENT_RESUME_REQUESTED");
-
                 if (checkIfDiscardAdRequired()) {
                     for (Long cuePoint : adTagCuePoints.getAdCuePoints()) {
                         if (cuePoint != 0 && cuePoint != -1 && ((cuePoint / Consts.MILLISECONDS_MULTIPLIER_FLOAT) < playbackStartPosition)) {

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -1165,8 +1165,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 if (checkIfDiscardAdRequired()) {
                     for (Long cuePoint : adTagCuePoints.getAdCuePoints()) {
                         if (cuePoint != 0 && cuePoint != -1 && ((cuePoint / Consts.MILLISECONDS_MULTIPLIER_FLOAT) < playbackStartPosition)) {
-                            log.d("discardAdBreak");
-                            // Discards current ad break and resumes content. If there is no current ad then the next ad break is discarded.
+                            log.d("discardAdBreak"); // Discards current ad break and resumes content. If there is no current ad then the next ad break is discarded.
                             adsManager.discardAdBreak();
                             playbackStartPosition = null; // making sure it will nu be done again.
                             break;

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -1258,6 +1258,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 }
 
                 isAdDisplayed = true;
+                isAdRequested = true;
                 messageBus.post(new AdEvent.AdStartedEvent(adInfo));
                 if (adsManager != null && appIsInBackground) {
                     log.d("AD STARTED and pause");

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -15,6 +15,7 @@ package com.kaltura.playkit.plugins.ima;
 import android.content.Context;
 import android.os.CountDownTimer;
 import android.os.Handler;
+
 import android.text.TextUtils;
 import android.view.View;
 import android.view.ViewGroup;
@@ -44,14 +45,17 @@ import com.kaltura.playkit.PKMediaConfig;
 import com.kaltura.playkit.PKMediaFormat;
 import com.kaltura.playkit.PKPlugin;
 import com.kaltura.playkit.Player;
+
 import com.kaltura.playkit.PlayerEngineWrapper;
 import com.kaltura.playkit.PlayerEvent;
+
 import com.kaltura.playkit.ads.AdTagType;
 import com.kaltura.playkit.ads.AdsPlayerEngineWrapper;
 import com.kaltura.playkit.ads.PKAdErrorType;
 import com.kaltura.playkit.ads.PKAdInfo;
 import com.kaltura.playkit.ads.PKAdPluginType;
 import com.kaltura.playkit.ads.PKAdProviderListener;
+
 import com.kaltura.playkit.player.PlayerEngine;
 import com.kaltura.playkit.player.PlayerSettings;
 import com.kaltura.playkit.plugin.ima.BuildConfig;


### PR DESCRIPTION
- Content player stuck issue fixed.
- adsManager.discardAdBreak() was not allowing the next ad to play in case if it was failing in the last ad pod. [Now removed this call]
- Instead stopping the videoPlayerWithAdPlayback
- As per IMA doc: Discards current ad break and resumes content. If there is no current ad then the next ad break is discarded.