### PR TITLE
FEC-9697 ADD Missing IMA DAI Parameters

### DIFF
--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIConfig.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIConfig.java
@@ -64,10 +64,7 @@ public class IMADAIConfig {
                          String videoId, // null for Live
                          String apiKey, // seems to be always null in demos
                          StreamRequest.StreamFormat streamFormat,
-                         String licenseUrl,
-                         HashMap<String, String> adTagParams,
-                         String streamActivityMonitorId,
-                         String authToken) {
+                         String licenseUrl) {
 
         this.assetKey = assetKey;
         this.contentSourceId = contentSourceId;
@@ -82,9 +79,6 @@ public class IMADAIConfig {
         this.adLoadTimeOut             = DEFAULT_AD_LOAD_TIMEOUT;
         this.enableDebugMode           = false;
         this.alwaysStartWithPreroll   = false;
-        this.adTagParams = adTagParams;
-        this.streamActivityMonitorId = streamActivityMonitorId;
-        this.authToken = authToken;
     }
 
     //VOD Factory
@@ -93,10 +87,7 @@ public class IMADAIConfig {
                                                   String videoId,
                                                   String apiKey,
                                                   StreamRequest.StreamFormat streamFormat,
-                                                  String licenseUrl,
-                                                  HashMap<String, String> adTagParams,
-                                                  String streamActivityMonitorId,
-                                                  String authToken) {
+                                                  String licenseUrl) {
 
         return new IMADAIConfig(assetTitle,
                 null,
@@ -104,10 +95,7 @@ public class IMADAIConfig {
                 videoId ,
                 apiKey,
                 streamFormat,
-                licenseUrl,
-                adTagParams,
-                streamActivityMonitorId,
-                authToken);
+                licenseUrl);
     }
 
     //Live Factory
@@ -115,20 +103,14 @@ public class IMADAIConfig {
                                                    String assetKey,
                                                    String apiKey,
                                                    StreamRequest.StreamFormat streamFormat,
-                                                   String licenseUrl,
-                                                   HashMap<String, String> adTagParams,
-                                                   String streamActivityMonitorId,
-                                                   String authToken) {
+                                                   String licenseUrl) {
         return new IMADAIConfig(assetTitle,
                 assetKey,
                 null,
                 null,
                 apiKey,
                 streamFormat,
-                licenseUrl,
-                adTagParams,
-                streamActivityMonitorId,
-                authToken);
+                licenseUrl);
     }
 
     public String getAssetTitle() {

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIConfig.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIConfig.java
@@ -18,8 +18,8 @@ import android.view.View;
 import com.google.ads.interactivemedia.v3.api.StreamRequest;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by gilad.nadav on 17/11/2016.
@@ -38,7 +38,7 @@ public class IMADAIConfig {
     private String videoId;
     private StreamRequest.StreamFormat streamFormat;
     private String licenseUrl;
-    private HashMap<String, String> adTagParams;
+    private Map<String, String> adTagParams;
     private String streamActivityMonitorId;
     private String authToken;
 
@@ -181,7 +181,7 @@ public class IMADAIConfig {
         return adLoadTimeOut;
     }
 
-    public HashMap<String, String> getAdTagParams() {
+    public Map<String, String> getAdTagParams() {
         return adTagParams;
     }
 
@@ -229,7 +229,7 @@ public class IMADAIConfig {
      * @param adTagParams optional ad tag params
      * @return IMADAIConfig
      */
-    public IMADAIConfig setAdTagParams(HashMap<String, String> adTagParams) {
+    public IMADAIConfig setAdTagParams(Map<String, String> adTagParams) {
         this.adTagParams = adTagParams;
         return this;
     }

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIConfig.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIConfig.java
@@ -283,4 +283,12 @@ public class IMADAIConfig {
     public boolean isLiveDAI() {
         return !TextUtils.isEmpty(assetKey);
     }
+
+    public boolean isVodDAI() {
+        return !TextUtils.isEmpty(contentSourceId) || !TextUtils.isEmpty(videoId);
+    }
+
+    public boolean isEmpty() {
+        return !this.isLiveDAI() && !this.isVodDAI();
+    }
 }

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIConfig.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIConfig.java
@@ -301,6 +301,4 @@ public class IMADAIConfig {
     public boolean isLiveDAI() {
         return !TextUtils.isEmpty(assetKey);
     }
-
-
 }

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIConfig.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIConfig.java
@@ -18,6 +18,7 @@ import android.view.View;
 import com.google.ads.interactivemedia.v3.api.StreamRequest;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -37,6 +38,9 @@ public class IMADAIConfig {
     private String videoId;
     private StreamRequest.StreamFormat streamFormat;
     private String licenseUrl;
+    private HashMap<String, String> adTagParams;
+    private String streamActivityMonitorId;
+    private String authToken;
 
     private String language;
     private boolean adAttribution;
@@ -60,7 +64,10 @@ public class IMADAIConfig {
                          String videoId, // null for Live
                          String apiKey, // seems to be always null in demos
                          StreamRequest.StreamFormat streamFormat,
-                         String licenseUrl) {
+                         String licenseUrl,
+                         HashMap<String, String> adTagParams,
+                         String streamActivityMonitorId,
+                         String authToken) {
 
         this.assetKey = assetKey;
         this.contentSourceId = contentSourceId;
@@ -75,6 +82,9 @@ public class IMADAIConfig {
         this.adLoadTimeOut             = DEFAULT_AD_LOAD_TIMEOUT;
         this.enableDebugMode           = false;
         this.alwaysStartWithPreroll   = false;
+        this.adTagParams = adTagParams;
+        this.streamActivityMonitorId = streamActivityMonitorId;
+        this.authToken = authToken;
     }
 
     //VOD Factory
@@ -83,7 +93,10 @@ public class IMADAIConfig {
                                                   String videoId,
                                                   String apiKey,
                                                   StreamRequest.StreamFormat streamFormat,
-                                                  String licenseUrl) {
+                                                  String licenseUrl,
+                                                  HashMap<String, String> adTagParams,
+                                                  String streamActivityMonitorId,
+                                                  String authToken) {
 
         return new IMADAIConfig(assetTitle,
                 null,
@@ -91,22 +104,31 @@ public class IMADAIConfig {
                 videoId ,
                 apiKey,
                 streamFormat,
-                licenseUrl);
+                licenseUrl,
+                adTagParams,
+                streamActivityMonitorId,
+                authToken);
     }
 
     //Live Factory
     public static IMADAIConfig getLiveIMADAIConfig(String assetTitle,
-                                                  String assetKey,
-                                                  String apiKey,
-                                                  StreamRequest.StreamFormat streamFormat,
-                                                  String licenseUrl) {
+                                                   String assetKey,
+                                                   String apiKey,
+                                                   StreamRequest.StreamFormat streamFormat,
+                                                   String licenseUrl,
+                                                   HashMap<String, String> adTagParams,
+                                                   String streamActivityMonitorId,
+                                                   String authToken) {
         return new IMADAIConfig(assetTitle,
                 assetKey,
                 null,
                 null,
                 apiKey,
                 streamFormat,
-                licenseUrl);
+                licenseUrl,
+                adTagParams,
+                streamActivityMonitorId,
+                authToken);
     }
 
     public String getAssetTitle() {
@@ -177,6 +199,18 @@ public class IMADAIConfig {
         return adLoadTimeOut;
     }
 
+    public HashMap<String, String> getAdTagParams() {
+        return adTagParams;
+    }
+
+    public String getStreamActivityMonitorId() {
+        return streamActivityMonitorId;
+    }
+
+    public String getAuthToken() {
+        return authToken;
+    }
+
     public IMADAIConfig setAdLoadTimeOut(int adLoadTimeOut) {
         this.adLoadTimeOut = adLoadTimeOut;
         return this;
@@ -199,6 +233,46 @@ public class IMADAIConfig {
 
     public IMADAIConfig setControlsOverlayList(List<View> controlsOverlayList) {
         this.controlsOverlayList = controlsOverlayList;
+        return this;
+    }
+
+    /**
+     * Sets the overridable ad tag parameters on the stream request.
+     * @see <a href="https://support.google.com/admanager/answer/7320899">Supply targeting parameters to your stream</a>
+     * provides more information.
+     * You can use the dai-ot and dai-ov parameters for stream variant preference
+     * @see <a href="https://support.google.com/admanager/answer/7320899">See Override Stream Variant Parameters </a>
+     * for more information.
+     *
+     * @param adTagParams optional ad tag params
+     * @return IMADAIConfig
+     */
+    public IMADAIConfig setAdTagParams(HashMap<String, String> adTagParams) {
+        this.adTagParams = adTagParams;
+        return this;
+    }
+
+    /**
+     * Sets the ID to be used to debug the stream with the stream activity monitor.
+     * This is used to provide a convenient way to allow publishers to find a stream
+     * log in the stream activity monitor tool.
+     *
+     * @param streamActivityMonitorId monitorId
+     * @return IMADAIConfig
+     */
+    public IMADAIConfig setStreamActivityMonitorId(String streamActivityMonitorId) {
+        this.streamActivityMonitorId = streamActivityMonitorId;
+        return this;
+    }
+
+    /**
+     * Sets the stream request authorization token. Used in place of the API key for stricter content authorization.
+     * The publisher can control individual content streams authorizations based on this token.
+     * @param authToken authToken
+     * @return IMADAIConfig
+     */
+    public IMADAIConfig setAuthToken(String authToken) {
+        this.authToken = authToken;
         return this;
     }
 
@@ -227,4 +301,6 @@ public class IMADAIConfig {
     public boolean isLiveDAI() {
         return !TextUtils.isEmpty(assetKey);
     }
+
+
 }

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIPlugin.java
@@ -249,8 +249,7 @@ public class IMADAIPlugin extends PKPlugin implements com.google.ads.interactive
 
     private void requestAdFromIMADAI() {
 
-        if (adConfig == null ||
-                (TextUtils.isEmpty(adConfig.getAssetKey()) && TextUtils.isEmpty(adConfig.getContentSourceId()) && TextUtils.isEmpty(adConfig.getVideoId()))) {
+        if (adConfig == null || adConfig.isEmpty()) {
             log.d("adConfig is null or empty DAI config. Calling prepare");
             isAdRequested = true;
             preparePlayer(true);
@@ -522,9 +521,12 @@ public class IMADAIPlugin extends PKPlugin implements com.google.ads.interactive
     protected void onUpdateConfig(Object config) {
         log.d("Start onUpdateConfig");
         adConfig = parseConfig(config);
-        if (adConfig == null) {
+        if (adConfig == null || adConfig.isEmpty()) {
             log.e("Error adConfig Incorrect or null");
-            adConfig = new IMADAIConfig();
+            isAdError = true;
+            if (adConfig == null) {
+                adConfig = new IMADAIConfig();
+            }
         }
     }
 

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIPlugin.java
@@ -368,10 +368,18 @@ public class IMADAIPlugin extends PKPlugin implements com.google.ads.interactive
                     adConfig.getVideoId(), adConfig.getApiKey());
         }
         // Set the stream format (HLS or DASH).
-        request.setFormat(adConfig.getStreamFormat());
-        request.setAdTagParameters(adConfig.getAdTagParams());
-        request.setStreamActivityMonitorId(adConfig.getStreamActivityMonitorId());
-        request.setAuthToken(adConfig.getAuthToken());
+        if (adConfig.getStreamFormat() != null) {
+            request.setFormat(adConfig.getStreamFormat());
+        }
+        if (adConfig.getAdTagParams() != null) {
+            request.setAdTagParameters(adConfig.getAdTagParams());
+        }
+        if (!TextUtils.isEmpty(adConfig.getStreamActivityMonitorId())) {
+            request.setStreamActivityMonitorId(adConfig.getStreamActivityMonitorId());
+        }
+        if (!TextUtils.isEmpty(adConfig.getAuthToken())) {
+            request.setAuthToken(adConfig.getAuthToken());
+        }
 
         return request;
     }

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIPlugin.java
@@ -500,7 +500,8 @@ public class IMADAIPlugin extends PKPlugin implements com.google.ads.interactive
                     return VideoProgressUpdate.VIDEO_TIME_NOT_READY;
                 }
                 long position = (long) streamManager.getStreamTimeForContentTime(getPlayerEngine().getCurrentPosition());
-                if (getPlayerEngine().isLive()) {
+                boolean isLiveDAI = adConfig.isLiveDAI();
+                if (isLiveDAI) {
                     long pos = getPlayerEngine().getCurrentPosition();
                     pos -= getPlayerEngine().getPositionInWindowMs();
                     position = Math.round(streamManager.getStreamTimeForContentTime(pos));
@@ -509,7 +510,7 @@ public class IMADAIPlugin extends PKPlugin implements com.google.ads.interactive
                 if (position < 0 || duration < 0) {
                     return VideoProgressUpdate.VIDEO_TIME_NOT_READY;
                 }
-                if (getPlayerEngine().isLive()) {
+                if (isLiveDAI) {
                     return new VideoProgressUpdate(position, duration);
                 }
                 return new VideoProgressUpdate(getPlayerEngine().getCurrentPosition(), getPlayerEngine().getDuration());

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIPlugin.java
@@ -126,7 +126,7 @@ public class IMADAIPlugin extends PKPlugin implements com.google.ads.interactive
         @Override
         public void warmUp(Context context) {
             log.d("warmUp started");
-            ImaSdkFactory.getInstance().createAdsLoader(context);
+          //  ImaSdkFactory.getInstance().createAdsLoader(context);
         }
     };
 
@@ -359,6 +359,9 @@ public class IMADAIPlugin extends PKPlugin implements com.google.ads.interactive
         }
         // Set the stream format (HLS or DASH).
         request.setFormat(adConfig.getStreamFormat());
+        request.setAdTagParameters(adConfig.getAdTagParams());
+        request.setStreamActivityMonitorId(adConfig.getStreamActivityMonitorId());
+        request.setAuthToken(adConfig.getAuthToken());
 
         return request;
     }
@@ -426,6 +429,16 @@ public class IMADAIPlugin extends PKPlugin implements com.google.ads.interactive
                 } else {
                     shouldPrepareOnResume = true;
                 }
+            }
+
+            @Override
+            public void pause() {
+
+            }
+
+            @Override
+            public void resume() {
+
             }
 
             @Override

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/imadai/IMADAIPlugin.java
@@ -126,7 +126,7 @@ public class IMADAIPlugin extends PKPlugin implements com.google.ads.interactive
         @Override
         public void warmUp(Context context) {
             log.d("warmUp started");
-          //  ImaSdkFactory.getInstance().createAdsLoader(context);
+            ImaSdkFactory.getInstance().createAdsLoader(context);
         }
     };
 
@@ -429,16 +429,6 @@ public class IMADAIPlugin extends PKPlugin implements com.google.ads.interactive
                 } else {
                     shouldPrepareOnResume = true;
                 }
-            }
-
-            @Override
-            public void pause() {
-
-            }
-
-            @Override
-            public void resume() {
-
             }
 
             @Override


### PR DESCRIPTION
Application can use the newly added optional apis in the following way. That's why these are not the part of constructor or factory method.

```
Map<String, String> map = new HashMap<>();
        map.put("iu","1234"); // Example

        return IMADAIConfig.getVodIMADAIConfig(assetTitle,
                contentSourceId,
                videoId,
                apiKey,
                streamFormat,
                licenseUrl)
                .setAdTagParams(map)
                .setAuthToken("AuthToken")
                .setStreamActivityMonitorId("MonitorId");
```

Fixes #93  
