### PR TITLE
FEC-11577 AdLayout Configuration

### DIFF
--- a/imaplugin/build.gradle
+++ b/imaplugin/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 apply from: 'version.gradle'
 
 android {
@@ -24,25 +23,17 @@ android {
         }
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
 }
 
 dependencies {
 
     // TODO: when playkit without plugins is released, replace this.
-    //implementation 'com.kaltura:playkit-android:dev-SNAPSHOT'
-    implementation project(":playkit")
-
-    // Kotlin Config
-    implementation 'androidx.core:core-ktx:1.3.2'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'com.kaltura:playkit-android:dev-SNAPSHOT'
+    //implementation project(":playkit")
 
     //Ads library.
     api 'com.google.ads.interactivemedia.v3:interactivemedia:3.24.0'
-    
+
     testImplementation 'junit:junit:4.13.2'
     implementation 'androidx.annotation:annotation:1.2.0'
 }

--- a/imaplugin/build.gradle
+++ b/imaplugin/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 apply from: 'version.gradle'
 
 android {
@@ -23,13 +24,21 @@ android {
         }
     }
 
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
 }
 
 dependencies {
 
     // TODO: when playkit without plugins is released, replace this.
-    implementation 'com.kaltura:playkit-android:dev-SNAPSHOT'
-    //implementation project(":playkit")
+    //implementation 'com.kaltura:playkit-android:dev-SNAPSHOT'
+    implementation project(":playkit")
+
+    // Kotlin Config
+    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     //Ads library.
     api 'com.google.ads.interactivemedia.v3:interactivemedia:3.24.0'

--- a/imaplugin/build.gradle
+++ b/imaplugin/build.gradle
@@ -46,4 +46,7 @@ repositories {
 
 if (!ext.libVersion.contains('dev')) {
     apply from: './gradle-mvn-push.gradle'
+} else {
+    apply from: './gradle-mvn-local.gradle'
 }
+

--- a/imaplugin/build.gradle
+++ b/imaplugin/build.gradle
@@ -33,7 +33,6 @@ dependencies {
 
     //Ads library.
     api 'com.google.ads.interactivemedia.v3:interactivemedia:3.24.0'
-
     testImplementation 'junit:junit:4.13.2'
     implementation 'androidx.annotation:annotation:1.2.0'
 }

--- a/imaplugin/build.gradle
+++ b/imaplugin/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 
     //Ads library.
     api 'com.google.ads.interactivemedia.v3:interactivemedia:3.24.0'
+    
     testImplementation 'junit:junit:4.13.2'
     implementation 'androidx.annotation:annotation:1.2.0'
 }

--- a/imaplugin/gradle-mvn-local.gradle
+++ b/imaplugin/gradle-mvn-local.gradle
@@ -1,0 +1,19 @@
+apply plugin: 'maven-publish'
+
+task androidSourcesJar(type: Jar) {
+    classifier 'sources'
+    from android.sourceSets.main.java.sourceFiles
+}
+
+project.afterEvaluate {
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                from components.release
+            }
+        }
+        repositories {
+            mavenLocal()
+        }
+    }
+}

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -949,6 +949,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         return isAdError;
     }
 
+    
     @Override
     public long getDuration() {
         VideoAdPlayer videoAdPlayer = videoPlayerWithAdPlayback != null ? videoPlayerWithAdPlayback.getVideoAdPlayer() : null;

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -634,7 +634,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     }
 
     private void requestAdsFromIMA(String adTagResponse, String adTagUrl) {
-        log.d("Do requestAdsFromIMA");
+        log.d("Do requestAdsFromIMA " + adTagUrl + "\n" + adTagResponse);
 
         // Create the ads request.
         AdsRequest request = sdkFactory.createAdsRequest();
@@ -1239,7 +1239,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
 
     private void resetFlagsOnError() {
         isAdError = true;
-        adPlaybackCancelled = true;
+        //adPlaybackCancelled = true; //TODO: Manage state of this flag when waterfalling happens
         isAdRequested = true;
         isAdDisplayed = false;
         cancelAdManagerTimer();

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -1413,6 +1413,12 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                         }
                     }
                 }
+
+                if (isContentEndedBeforeMidroll && isAdvertisingConfigured) {
+                    isAdDisplayed = false;
+                    isAdvertisingConfigLoading = false;
+                }
+
                 // AdEventType.CONTENT_RESUME_REQUESTED is fired when the ad is completed
                 // and you should start playing your content.
                 if (isContentEndedBeforeMidroll && !isAllAdsCompleted && getPlayerEngine() != null && getPlayerEngine().getCurrentPosition() >= getPlayerEngine().getDuration()) {

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -1035,21 +1035,16 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     }
 
     private AdInfo createAdInfo(Ad ad) {
-        String adDescription;
-        String adTitle;
+
         long adPodTimeOffset;
         int podCount;
         int podIndex;
 
         if (isAdvertisingConfigured && pkAdvertisingAdInfo != null) {
-            adDescription = pkAdvertisingAdInfo.getAdDescription();
-            adTitle = pkAdvertisingAdInfo.getAdTitle();
             adPodTimeOffset = pkAdvertisingAdInfo.getAdPodTimeOffset();
             podCount = pkAdvertisingAdInfo.getPodCount();
             podIndex = pkAdvertisingAdInfo.getPodIndex();
         } else {
-            adDescription = ad.getDescription() != null ? ad.getDescription() : "";
-            adTitle = ad.getTitle();
             adPodTimeOffset = (long) ad.getAdPodInfo().getTimeOffset() * Consts.MILLISECONDS_MULTIPLIER;
             podCount = (adsManager != null && adsManager.getAdCuePoints() != null) ? adsManager.getAdCuePoints().size() : 0;
             podIndex = (ad.getAdPodInfo().getPodIndex() >= 0) ? ad.getAdPodInfo().getPodIndex() + 1 : podCount; // index starts in 0
@@ -1057,6 +1052,9 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 podCount = 1;
             }
         }
+
+        String adDescription = ad.getDescription() != null ? ad.getDescription() : "";
+        String adTitle = ad.getTitle();
 
         long adDuration = (long) ad.getDuration() * Consts.MILLISECONDS_MULTIPLIER;
         long adPlayHead = getCurrentPosition() * Consts.MILLISECONDS_MULTIPLIER;

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -948,7 +948,6 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         log.d("isAdError: " + isAdError);
         return isAdError;
     }
-
     
     @Override
     public long getDuration() {

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -615,7 +615,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         if (adConfig != null) {
             adTagResponse = adConfig.getAdTagResponse();
         }
-        if (!isAdvertisingConfigured && TextUtils.isEmpty(adTagUrl) && TextUtils.isEmpty(adTagResponse)) {
+        if (TextUtils.isEmpty(adTagUrl) && TextUtils.isEmpty(adTagResponse)) {
             log.d("AdTag is empty avoiding ad request");
             isAdRequested = true;
             if (adTagCuePoints != null && adTagCuePoints.getAdCuePoints() != null) {

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -827,7 +827,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     }
 
     @Override
-    public void playAdNow(String adTag) {
+    public void advertisingPlayAdNow(String adTag) {
         log.d("playAdNow adType: " + adType + " \n and adTag: " + adTag);
         if (isAdvertisingConfigured) {
             isAdError = false;
@@ -854,7 +854,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     }
 
     @Override
-    public void setCuePoints(List<Long> cuePoints) {
+    public void advertisingSetCuePoints(List<Long> cuePoints) {
         log.d("setCuePoints");
         if (isAdvertisingConfigured && cuePoints != null && !cuePoints.isEmpty()) {
             advertisingConfigCuePoints = cuePoints;
@@ -863,12 +863,12 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     }
 
     @Override
-    public void setAdInfo(PKAdvertisingAdInfo pkAdvertisingAdInfo) {
+    public void advertisingSetAdInfo(PKAdvertisingAdInfo pkAdvertisingAdInfo) {
         this.pkAdvertisingAdInfo = pkAdvertisingAdInfo;
     }
 
     @Override
-    public void adControllerPreparePlayer() {
+    public void advertisingPreparePlayer() {
         if (isAdvertisingConfigured) {
             isAdvertisingConfigLoading = false;
             displayContent();

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -825,7 +825,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         if (isAdvertisingConfigured && cuePoints != null && !cuePoints.isEmpty()) {
             advertisingConfigCuePoints = cuePoints;
             midrollAdBreakPositionType = adBreakPositionType;
-            if (isUpdatedCuePoint && midrollAdBreakPositionType == AdBreakPositionType.PERCENTAGE) {
+            if (isUpdatedCuePoint && midrollAdBreakPositionType != AdBreakPositionType.POSITION) {
                 sendCuePointsUpdateEvent();
             }
         }
@@ -1492,7 +1492,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                     preparePlayer(false);
                 }
 
-                if (adTagCuePoints == null && midrollAdBreakPositionType != AdBreakPositionType.PERCENTAGE) {
+                if (adTagCuePoints == null && midrollAdBreakPositionType != AdBreakPositionType.POSITION) {
                     Handler handler = new Handler();
                     handler.postDelayed(() -> {
                         log.d("AD CUEPOINTS CHANGED TRIGGERED WITH DELAY");
@@ -1581,7 +1581,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 messageBus.post(new AdEvent(AdEvent.Type.AD_BREAK_ENDED));
                 break;
             case CUEPOINTS_CHANGED:
-                if (midrollAdBreakPositionType != AdBreakPositionType.PERCENTAGE) {
+                if (midrollAdBreakPositionType != AdBreakPositionType.POSITION) {
                     sendCuePointsUpdateEvent();
                 }
                 break;
@@ -1689,7 +1689,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
             //Attach event and error event listeners.
             adsManager.addAdErrorListener(IMAPlugin.this);
             adsManager.addAdEventListener(IMAPlugin.this);
-            if (midrollAdBreakPositionType != AdBreakPositionType.PERCENTAGE) {
+            if (midrollAdBreakPositionType != AdBreakPositionType.POSITION) {
                 sendCuePointsUpdateEvent();
             }
 

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -275,7 +275,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         clearAdsLoader();
         imaSetup();
         log.d("adtag = " + adConfig.getAdTagUrl());
-        requestAdsOnChangeMedia(adConfig.getAdTagUrl());
+        requestAdsOnUpdateMedia(adConfig.getAdTagUrl());
     }
 
     private AdDisplayContainer createAdDisplayContainer() {
@@ -424,7 +424,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         imaSdkSettings.setPlayerType(adConfig.getPlayerType());
         imaSdkSettings.setPlayerVersion(adConfig.getPlayerVersion());
         // Tell the SDK we want to control ad break playback.
-        //imaSdkSettings.setAutoPlayAdBreaks(false);
+        //imaSdkSettings.setAutoPlayAdBreaks(true);
         if (adConfig.getMaxRedirects() > 0) {
             imaSdkSettings.setMaxRedirects(adConfig.getMaxRedirects());
         }
@@ -609,7 +609,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         }
     }
 
-    private void requestAdsOnChangeMedia(String adTagUrl) {
+    private void requestAdsOnUpdateMedia(String adTagUrl) {
         log.d("Do requestAdsOnChangeMedia");
         String adTagResponse = null;
         if (adConfig != null) {

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -729,7 +729,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                     if (getPlayerEngine() != null) {
                         getPlayerEngine().play();
                     }
-                    //TODO: Check if content player should be hidden here
+
                     messageBus.post(new AdEvent(AdEvent.Type.AD_BREAK_IGNORED));
                     if (isAdRequested) {
                         adPlaybackCancelled = true;
@@ -1276,7 +1276,11 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
 
     private void resetFlagsOnError() {
         isAdError = true;
-        //adPlaybackCancelled = true; //TODO: Manage state of this flag when waterfalling happens
+        // This check is required because AdError comes for Advertising config and
+        // From Controller level, waterfalling will be triggered
+        if (!isAdvertisingConfigured) {
+            adPlaybackCancelled = true;
+        }
         isAdRequested = true;
         isAdDisplayed = false;
         cancelAdManagerTimer();

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -50,6 +50,7 @@ import com.kaltura.playkit.PlayerEngineWrapper;
 import com.kaltura.playkit.PlayerEvent;
 import com.kaltura.playkit.ads.AdBreakPositionType;
 import com.kaltura.playkit.ads.AdTagType;
+import com.kaltura.playkit.ads.AdType;
 import com.kaltura.playkit.ads.AdsPlayerEngineWrapper;
 import com.kaltura.playkit.ads.IMAEventsListener;
 import com.kaltura.playkit.ads.PKAdErrorType;
@@ -127,11 +128,6 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     private boolean appIsInBackground;
     private boolean isContentEndedBeforeMidroll;
     private boolean isReleaseContentPlayerRequired;
-    private boolean isAdvertisingConfigured;
-    private boolean isAdvertisingConfigLoading;
-    private List<Long> advertisingConfigCuePoints;
-    private AdBreakPositionType midrollAdBreakPositionType = AdBreakPositionType.POSITION;
-    private PKAdvertisingAdInfo pkAdvertisingAdInfo = null;
 
     private boolean isContentPrepared;
     private boolean isAutoPlay;
@@ -141,10 +137,17 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     private AdEvent.Type lastAdEventReceived;
     private boolean adManagerInitDuringBackground;
     private PKAdProviderListener pkAdProviderListener;
-    private IMAEventsListener imaEventsListener;
     private Long playbackStartPosition;
     private PlayerEngineWrapper adsPlayerEngineWrapper;
     private Boolean playerPlayingBeforeAdArrived;
+
+    // Advertsing Configuration
+    private boolean isAdvertisingConfigured;
+    private IMAEventsListener imaEventsListener;
+    private boolean isAdvertisingConfigLoading;
+    private List<Long> advertisingConfigCuePoints;
+    private PKAdvertisingAdInfo pkAdvertisingAdInfo = null;
+    private AdType adType = AdType.AD_URL;
 
     private Map<com.google.ads.interactivemedia.v3.api.AdEvent.AdEventType, AdEvent.Type> adEventsMap;
 
@@ -573,6 +576,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         boolean adManagerInitialized = (adsManager != null); // FEM-2600
         log.d("IMA onDestroy adManagerInitialized = " + adManagerInitialized);
         destroyIMA();
+        resetAdvertisingConfig();
         if (videoPlayerWithAdPlayback != null) {
             videoPlayerWithAdPlayback.removeAdPlaybackEventListener();
             videoPlayerWithAdPlayback.releasePlayer();
@@ -609,6 +613,16 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         }
     }
 
+    private void resetAdvertisingConfig() {
+        log.d("resetAdvertisingConfig");
+        isAdvertisingConfigured = false;
+        imaEventsListener = null;
+        isAdvertisingConfigLoading = false;
+        advertisingConfigCuePoints = null;
+        pkAdvertisingAdInfo = null;
+        adType = AdType.AD_URL;
+    }
+
     private void cancelAdManagerTimer() {
         if (adManagerTimer != null) {
             log.d("cancelAdManagerTimer");
@@ -618,7 +632,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     }
 
     private void requestAdsOnUpdateMedia(String adTagUrl) {
-        log.d("Do requestAdsOnChangeMedia");
+        log.d("Do requestAdsOnUpdateMedia");
         String adTagResponse = null;
         if (adConfig != null) {
             adTagResponse = adConfig.getAdTagResponse();
@@ -807,27 +821,32 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     }
 
     @Override
-    public void playAdNow(String adTagUrl) {
+    public void playAdNow(String adTag) {
+        log.d("playAdNow adType: " + adType + " \n and adTag: " + adTag);
         if (isAdvertisingConfigured) {
-            isAdvertisingConfigLoading = !TextUtils.isEmpty(adTagUrl);
-            requestAdsFromIMA(null, adTagUrl);
+            isAdvertisingConfigLoading = !TextUtils.isEmpty(adTag);
+            if (adType == AdType.AD_RESPONSE) {
+                requestAdsFromIMA(adTag, null);
+            } else {
+                requestAdsFromIMA(null, adTag);
+            }
         }
     }
 
     @Override
-    public void setAdvertisingConfig(boolean isConfigured, IMAEventsListener imaEventsListener) {
+    public void setAdvertisingConfig(boolean isConfigured, @NonNull AdType adType, IMAEventsListener imaEventsListener) {
+        resetAdvertisingConfig();
         isAdvertisingConfigured = isConfigured;
         this.imaEventsListener = imaEventsListener;
+        this.adType = adType;
     }
 
     @Override
-    public void setCuePoints(List<Long> cuePoints, AdBreakPositionType adBreakPositionType, boolean isUpdatedCuePoint) {
+    public void setCuePoints(List<Long> cuePoints) {
+        log.d("setCuePoints");
         if (isAdvertisingConfigured && cuePoints != null && !cuePoints.isEmpty()) {
             advertisingConfigCuePoints = cuePoints;
-            midrollAdBreakPositionType = adBreakPositionType;
-            if (isUpdatedCuePoint && midrollAdBreakPositionType != AdBreakPositionType.POSITION) {
-                sendCuePointsUpdateEvent();
-            }
+            sendCuePointsUpdateEvent();
         }
     }
 
@@ -1492,14 +1511,13 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                     preparePlayer(false);
                 }
 
-                if (adTagCuePoints == null && midrollAdBreakPositionType != AdBreakPositionType.POSITION) {
-                    Handler handler = new Handler();
-                    handler.postDelayed(() -> {
-                        log.d("AD CUEPOINTS CHANGED TRIGGERED WITH DELAY");
-                        sendCuePointsUpdateEvent();
+                Handler handler = new Handler();
+                handler.postDelayed(() -> {
+                    log.d("AD CUEPOINTS CHANGED TRIGGERED WITH DELAY");
+                    sendCuePointsUpdateEvent();
 
-                    }, IMAConfig.DEFAULT_CUE_POINTS_CHANGED_DELAY);
-                }
+                }, IMAConfig.DEFAULT_CUE_POINTS_CHANGED_DELAY);
+
                 break;
             case PAUSED:
                 log.d("AD PAUSED isAdIsPaused = true");
@@ -1581,9 +1599,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 messageBus.post(new AdEvent(AdEvent.Type.AD_BREAK_ENDED));
                 break;
             case CUEPOINTS_CHANGED:
-                if (midrollAdBreakPositionType != AdBreakPositionType.POSITION) {
-                    sendCuePointsUpdateEvent();
-                }
+                sendCuePointsUpdateEvent();
                 break;
             case AD_BREAK_FETCH_ERROR:
                 log.d("AD AD_BREAK_FETCH_ERROR");
@@ -1689,9 +1705,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
             //Attach event and error event listeners.
             adsManager.addAdErrorListener(IMAPlugin.this);
             adsManager.addAdEventListener(IMAPlugin.this);
-            if (midrollAdBreakPositionType != AdBreakPositionType.POSITION) {
-                sendCuePointsUpdateEvent();
-            }
+            sendCuePointsUpdateEvent();
 
             if (isInitWaiting) {
                 adsManager.init(getRenderingSettings());

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -1364,6 +1364,9 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 }
                 break;
             case CONTENT_PAUSE_REQUESTED:
+                if (getIMAEventsListener() != null) {
+                    imaEventsListener.contentPauseRequested();
+                }
                 log.d("CONTENT_PAUSE_REQUESTED appIsInBackground = " + appIsInBackground + " lastPlaybackPlayerState = " + lastPlaybackPlayerState);
                 playerPlayingBeforeAdArrived = getPlayerEngine().isPlaying() || (lastPlaybackPlayerState != null && lastPlaybackPlayerState == PlayerEvent.Type.ENDED);
                 log.d("CONTENT_PAUSE_REQUESTED playerPlayingBeforeAdArrived = " + playerPlayingBeforeAdArrived);
@@ -1394,6 +1397,9 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 messageBus.post(new AdEvent(AdEvent.Type.CONTENT_PAUSE_REQUESTED));
                 break;
             case CONTENT_RESUME_REQUESTED:
+                if (getIMAEventsListener() != null) {
+                    imaEventsListener.contentResumeRequested();
+                }
                 log.d("AD REQUEST AD_CONTENT_RESUME_REQUESTED");
                 if (checkIfDiscardAdRequired()) {
                     for (Long cuePoint : adTagCuePoints.getAdCuePoints()) {
@@ -1422,6 +1428,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
 
                 messageBus.post(new AdEvent(AdEvent.Type.CONTENT_RESUME_REQUESTED));
                 isAdDisplayed = false;
+                isAdvertisingConfigLoading = false;
                 if (videoPlayerWithAdPlayback != null) {
                     videoPlayerWithAdPlayback.resumeContentAfterAdPlayback();
                 }

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -1334,14 +1334,18 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 }
                 break;
             case ALL_ADS_COMPLETED:
-                log.d("AD_ALL_ADS_COMPLETED");
-                isAllAdsCompleted = true;
-                messageBus.post(new AdEvent(AdEvent.Type.ALL_ADS_COMPLETED));
-                displayContent();
+                if (!isAdvertisingConfigured) {
+                    log.d("AD_ALL_ADS_COMPLETED");
+                    isAllAdsCompleted = true;
+                    messageBus.post(new AdEvent(AdEvent.Type.ALL_ADS_COMPLETED));
+                    displayContent();
 
-                if (adsManager != null) {
-                    log.d("AD_ALL_ADS_COMPLETED onDestroy");
-                    // destroyIMA();
+                    if (adsManager != null) {
+                        log.d("AD_ALL_ADS_COMPLETED onDestroy");
+                        destroyIMA();
+                    }
+                } else {
+                    log.d("Masking AD_ALL_ADS_COMPLETED event because advertising is configured");
                 }
                 break;
             case STARTED:

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -48,7 +48,6 @@ import com.kaltura.playkit.PKPlugin;
 import com.kaltura.playkit.Player;
 import com.kaltura.playkit.PlayerEngineWrapper;
 import com.kaltura.playkit.PlayerEvent;
-import com.kaltura.playkit.ads.AdBreakPositionType;
 import com.kaltura.playkit.ads.AdTagType;
 import com.kaltura.playkit.ads.AdType;
 import com.kaltura.playkit.ads.AdsPlayerEngineWrapper;

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -618,14 +618,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
             adTagResponse = adConfig.getAdTagResponse();
         }
         if (!isAdvertisingConfigured && TextUtils.isEmpty(adTagUrl) && TextUtils.isEmpty(adTagResponse)) {
-            log.d("AdTag is empty avoiding ad request");
-            isAdRequested = true;
-            if (adTagCuePoints != null && adTagCuePoints.getAdCuePoints() != null) {
-                adTagCuePoints.getAdCuePoints().clear();
-                adTagCuePoints = null;
-            }
-            displayContent();
-            preparePlayer(false);
+            prepareContentPlayer();
             return;
         }
         resetIMA();
@@ -637,6 +630,11 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
 
     private void requestAdsFromIMA(String adTagResponse, String adTagUrl) {
         log.d("Do requestAdsFromIMA " + adTagUrl + "\n" + adTagResponse);
+
+        if (TextUtils.isEmpty(adTagUrl) && TextUtils.isEmpty(adTagResponse)) {
+            prepareContentPlayer();
+            return;
+        }
 
         // Create the ads request.
         final AdsRequest request = sdkFactory.createAdsRequest();
@@ -663,6 +661,17 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         isInitWaiting = true;
         adsLoader.requestAds(request);
         adManagerTimer.start();
+    }
+
+    private void prepareContentPlayer() {
+        log.d("AdTag is empty avoiding ad request");
+        isAdRequested = true;
+        if (adTagCuePoints != null && adTagCuePoints.getAdCuePoints() != null) {
+            adTagCuePoints.getAdCuePoints().clear();
+            adTagCuePoints = null;
+        }
+        displayContent();
+        preparePlayer(false);
     }
 
     @NonNull

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -799,8 +799,10 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
 
     @Override
     public void playAdNow(String adTagUrl) {
-        isAdvertisingConfigLoading = !TextUtils.isEmpty(adTagUrl);
-        requestAdsFromIMA(null, adTagUrl);
+        if (isAdvertisingConfigured) {
+            isAdvertisingConfigLoading = !TextUtils.isEmpty(adTagUrl);
+            requestAdsFromIMA(null, adTagUrl);
+        }
     }
 
     @Override
@@ -811,12 +813,25 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
 
     @Override
     public void setAllAdsCompleted() {
-        //TODO
+        if (isAdvertisingConfigured) {
+            //TODO
+        }
     }
 
     @Override
     public void adControllerPreparePlayer() {
-        isAdvertisingConfigLoading = false;
+        if (isAdvertisingConfigured) {
+            isAdvertisingConfigLoading = false;
+            displayContent();
+            getPlayerEngine().play();
+        }
+    }
+
+    private boolean isAdvertisingConfigLoading() {
+        if (isAdvertisingConfigured) {
+            return isAdvertisingConfigLoading;
+        }
+        return false;
     }
 
     @Override
@@ -1144,7 +1159,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     }
 
     private void displayContent() {
-        if (isAdvertisingConfigLoading) {
+        if (isAdvertisingConfigLoading()) {
             log.d("in displayContent but AdvertisingConfigLoading, hence returning");
             return;
         }
@@ -1182,7 +1197,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
 
                             IMAPlugin.this.displayContent();
                             if (IMAPlugin.this.getPlayerEngine() != null) {
-                                if (isAdvertisingConfigLoading) {
+                                if (isAdvertisingConfigLoading()) {
                                     displayAd();
                                 } else {
                                     IMAPlugin.this.getPlayerEngine().play();
@@ -1347,7 +1362,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                                 preparePlayer(false);
                             }
                             if (getPlayerEngine() != null) {
-                                if (isAdvertisingConfigLoading) {
+                                if (isAdvertisingConfigLoading()) {
                                     displayAd();
                                 } else {
                                     getPlayerEngine().play();
@@ -1361,7 +1376,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                     log.d("Content prepared.. lastPlaybackPlayerState = " + lastPlaybackPlayerState + ", time = " + position + "/" + duration);
                     if (duration < 0) {
                         preparePlayer(false);
-                        if (isAdvertisingConfigLoading) {
+                        if (isAdvertisingConfigLoading()) {
                             displayAd();
                         } else {
                             getPlayerEngine().play();
@@ -1369,7 +1384,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                     } else if (lastPlaybackPlayerState != PlayerEvent.Type.ENDED && position <= duration) {
                         if (adInfo == null || (adInfo.getAdPositionType() != AdPositionType.POST_ROLL)) {
                             log.d("Content prepared.. Play called.");
-                            if (isAdvertisingConfigLoading) {
+                            if (isAdvertisingConfigLoading()) {
                                 displayAd();
                             } else {
                                 getPlayerEngine().play();
@@ -1746,7 +1761,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     }
 
     private IMAEventsListener getIMAEventsListener() {
-        if (imaEventsListener == null) {
+        if (!isAdvertisingConfigured || imaEventsListener == null) {
             return null;
         }
         return imaEventsListener;

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -1021,7 +1021,9 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 adCuePoints.add(0L);
             }
         } else {
-            adCuePoints.addAll(advertisingConfigCuePoints);
+            if (advertisingConfigCuePoints != null && advertisingConfigCuePoints.size() > 0) {
+                adCuePoints.addAll(advertisingConfigCuePoints);
+            }
         }
 
         return adCuePoints;

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -275,6 +275,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         isContentEndedBeforeMidroll = false;
         lastPlaybackPlayerState = null;
         lastAdEventReceived = null;
+        isInitWaiting = false;
 
         if (videoPlayerWithAdPlayback == null) {
             log.d("onUpdateMedia videoPlayerWithAdPlayback = null recreating it");
@@ -689,7 +690,6 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         //request.setAdWillAutoPlay(isAutoPlay);
         // Request the ad. After the ad is loaded, onAdsManagerLoaded() will be called.
         adManagerTimer = getCountDownTimer();
-        isInitWaiting = true;
         adsLoader.requestAds(request);
         adManagerTimer.start();
     }
@@ -831,7 +831,13 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     public void playAdNow(String adTag) {
         log.d("playAdNow adType: " + adType + " \n and adTag: " + adTag);
         if (isAdvertisingConfigured) {
+            isAdError = false;
+            isAdRequested = false;
             isAdvertisingConfigLoading = !TextUtils.isEmpty(adTag);
+            if (adInfo != null || (player != null && player.getCurrentPosition() > 0)) {
+                log.d("playAdNow isInitWaiting = true");
+                isInitWaiting = true;
+            }
             if (adType == AdType.AD_RESPONSE) {
                 requestAdsFromIMA(adTag, null);
             } else {
@@ -1209,7 +1215,10 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         if (PKAdErrorType.COMPANION_AD_LOADING_FAILED.equals(errorType)) {
             return;
         }
-        preparePlayer(isAutoPlay);
+
+        if (!isAdvertisingConfigLoading()) {
+            preparePlayer(isAutoPlay);
+        }
     }
 
     private void displayAd() {

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -1342,9 +1342,6 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 }
                 break;
             case CONTENT_PAUSE_REQUESTED:
-                if (getIMAEventsListener() != null) {
-                    imaEventsListener.contentPauseRequested();
-                }
                 log.d("CONTENT_PAUSE_REQUESTED appIsInBackground = " + appIsInBackground + " lastPlaybackPlayerState = " + lastPlaybackPlayerState);
                 playerPlayingBeforeAdArrived = getPlayerEngine().isPlaying() || (lastPlaybackPlayerState != null && lastPlaybackPlayerState == PlayerEvent.Type.ENDED);
                 log.d("CONTENT_PAUSE_REQUESTED playerPlayingBeforeAdArrived = " + playerPlayingBeforeAdArrived);
@@ -1375,9 +1372,6 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 messageBus.post(new AdEvent(AdEvent.Type.CONTENT_PAUSE_REQUESTED));
                 break;
             case CONTENT_RESUME_REQUESTED:
-                if (getIMAEventsListener() != null) {
-                    imaEventsListener.contentResumeRequested();
-                }
                 log.d("AD REQUEST AD_CONTENT_RESUME_REQUESTED");
                 if (checkIfDiscardAdRequired()) {
                     for (Long cuePoint : adTagCuePoints.getAdCuePoints()) {
@@ -1536,9 +1530,6 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 }
                 break;
             case COMPLETED:
-                if (getIMAEventsListener() != null) {
-                    imaEventsListener.adCompleted();
-                }
                 log.d("AD COMPLETED");
                 messageBus.post(new AdEvent(AdEvent.Type.COMPLETED));
                 break;

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -1368,7 +1368,11 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                     imaEventsListener.contentPauseRequested();
                 }
                 log.d("CONTENT_PAUSE_REQUESTED appIsInBackground = " + appIsInBackground + " lastPlaybackPlayerState = " + lastPlaybackPlayerState);
-                playerPlayingBeforeAdArrived = getPlayerEngine().isPlaying() || (lastPlaybackPlayerState != null && lastPlaybackPlayerState == PlayerEvent.Type.ENDED);
+
+                playerPlayingBeforeAdArrived = (isAdvertisingConfigured && !getPlayerEngine().isPlaying()) ||
+                        getPlayerEngine().isPlaying() ||
+                        (lastPlaybackPlayerState != null && lastPlaybackPlayerState == PlayerEvent.Type.ENDED);
+
                 log.d("CONTENT_PAUSE_REQUESTED playerPlayingBeforeAdArrived = " + playerPlayingBeforeAdArrived);
 
                 if (getPlayerEngine() != null) {

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -141,7 +141,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     private PlayerEngineWrapper adsPlayerEngineWrapper;
     private Boolean playerPlayingBeforeAdArrived;
 
-    // Advertsing Configuration
+    // Advertising Configuration
     private boolean isAdvertisingConfigured;
     private IMAEventsListener imaEventsListener;
     private boolean isAdvertisingConfigLoading;

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -637,7 +637,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         log.d("Do requestAdsFromIMA " + adTagUrl + "\n" + adTagResponse);
 
         // Create the ads request.
-        AdsRequest request = sdkFactory.createAdsRequest();
+        final AdsRequest request = sdkFactory.createAdsRequest();
         if (TextUtils.isEmpty(adTagUrl)) {
             request.setAdsResponse(adTagResponse);
         } else{
@@ -655,7 +655,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
             request.setContentDuration(adConfig.getContentDuration());
         }
         //request.setContinuousPlayback(true);
-        // request.setAdWillAutoPlay(false);
+        //request.setAdWillAutoPlay(isAutoPlay);
         // Request the ad. After the ad is loaded, onAdsManagerLoaded() will be called.
         adManagerTimer = getCountDownTimer();
         isInitWaiting = true;
@@ -1106,82 +1106,6 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         preparePlayer(isAutoPlay);
     }
 
-    //    2021-09-29 11:18:57.214 18935-18935/com.kaltura.playkitdemo E/IMAPlugin: Gourav => adInfo.getAdPositionType() MID_ROLL adInfo.getAdIndexInPod() 1 adInfo.getPodIndex() 2 adInfo.getPodCount() 3 adInfo.getTotalAdsInPod() 5 adInfo.isBumper() false
-//            2021-09-29 11:18:57.214 18935-18935/com.kaltura.playkitdemo E/IMAPlugin: Gourav => adInfo.getAdPodTimeOffset() 15000 adInfo.getAdPlayHead() 0
-//            2021-09-29 11:19:10.736 18935-18935/com.kaltura.playkitdemo E/IMAPlugin: Gourav => adInfo.getAdPositionType() MID_ROLL adInfo.getAdIndexInPod() 2 adInfo.getPodIndex() 2 adInfo.getPodCount() 3 adInfo.getTotalAdsInPod() 5 adInfo.isBumper() false
-//            2021-09-29 11:19:10.736 18935-18935/com.kaltura.playkitdemo E/IMAPlugin: Gourav => adInfo.getAdPodTimeOffset() 15000 adInfo.getAdPlayHead() 0
-//            2021-09-29 11:19:21.503 18935-18935/com.kaltura.playkitdemo E/IMAPlugin: Gourav => adInfo.getAdPositionType() MID_ROLL adInfo.getAdIndexInPod() 3 adInfo.getPodIndex() 2 adInfo.getPodCount() 3 adInfo.getTotalAdsInPod() 5 adInfo.isBumper() false
-
-
-   /* private void extractWaterfallAd(AdPositionType adPositionType) {
-        if (adConfig.getAdvertisingWaterFall() == null || adConfig.getAdvertisingWaterFall().getAdBreaks() == null) {
-            return;
-        }
-        
-        String adTag = null;
-        int position = -1;
-
-        List<AdBreaks> adBreakList = adConfig.getAdvertisingWaterFall().getAdBreaks();
-
-        if (adPositionType == AdPositionType.PRE_ROLL) {
-            Ads ads = null;
-            for (int i = 0; i < adBreakList.size(); i++) {
-                if (adBreakList.get(i).getPosition() == 0) {
-                    ads = adBreakList.get(i).getAds();
-                    break;
-                }
-            }
-
-            if (ads != null) {
-                List<AdUrl> adUrlsList = ads.getAdUrls();
-            }
-
-        }
-        
-        
-       // ads
-        playWaterfallAd("https://pubads.g.doubleclick.net/gampad/live/ads?slotname=/21633895671/QA/Android_Native_App/COI&sz=640x360&ciu_szs=&cust_params=sample_ar%3Dskippablelinear%26Gender%3DM%26Age%3D33%26KidsPinEnabled%3DN%26distinct_id%3D42c92f17603e4ee2b4232666b9591134%26AppVersion%3D0.1.80%26DeviceModel%3Dmoto+g(6)%26OptOut%3DFalse%26OSVersion%3D9%26PackageName%3Dcom.tv.v18.viola%26first_time%3DFalse%26logintype%3DTraditional&url=&unviewed_position_start=1&output=xml_vast3&impl=s&env=vp&gdfp_req=1&ad_rule=0&video_url_to_fetch=https%253A%252F%252Fwww.voot.com&vad_type=linear&vpos=preroll&pod=1&ppos=1&lip=true&min_ad_duration=0&max_ad_duration=65000&vrid=1095418&ppid=42c92f17603e4ee2b4232666b9591134&correlator=10771&lpr=true&cmsid=2467608&video_doc_id=0_im5ianso&kfa=0&tfcd=0");
-    }
-
-    private void playWaterfallAd(String adTag) {
-        final AdsRequest request = sdkFactory.createAdsRequest();
-        request.setAdTagUrl(adTag);
-        //  request.setAdTagUrl("https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpremidpost&cmsid=496&vid=short_onecue&correlator=");
-
-//                if (adConfig.getAdLoadTimeOut() > 0 && adConfig.getAdLoadTimeOut() < Consts.MILLISECONDS_MULTIPLIER && adConfig.getAdLoadTimeOut() != IMAConfig.DEFAULT_AD_LOAD_TIMEOUT) {
-//                    request.setVastLoadTimeout(adConfig.getAdLoadTimeOut() * Consts.MILLISECONDS_MULTIPLIER);
-//                }
-//                if (videoPlayerWithAdPlayback != null) {
-//                    request.setContentProgressProvider(videoPlayerWithAdPlayback.getContentProgressProvider());
-//                }
-//
-//                if (adConfig != null) {
-//                    request.setContentDuration(adConfig.getContentDuration());
-//                }
-        //request.setContinuousPlayback(true);
-        //request.setAdWillAutoPlay(isAutoPlay);
-        // Request the ad. After the ad is loaded, onAdsManagerLoaded() will be called.
-        //  adManagerTimer = getCountDownTimer();
-        //  ImaSdkSettings imaSdkSettings = ImaSdkFactory.getInstance().createImaSdkSettings();
-        //    imaSdkSettings.setAutoPlayAdBreaks(false);
-        isInitWaiting = true;
-        adsLoader = sdkFactory.createAdsLoader(context, imaSdkSettings, ImaSdkFactory.createAdDisplayContainer(videoPlayerWithAdPlayback.getAdUiContainer(), videoPlayerWithAdPlayback.getVideoAdPlayer()));
-        // Add listeners for when ads are loaded and for errors.
-        adsLoader.addAdErrorListener(this);
-        adsLoader.addAdsLoadedListener(getAdsLoadedListener());
-        adsLoader.requestAds(request);
-    }*/
-
-//    private void checkIfWaterfallAdBePlayed() {
-//        if (adConfig.getAdvertisingWaterFall() == null) {
-//            return;
-//        }
-//
-//        if (adInfo == null && player != null) {
-//
-//        }
-//    }
-
     private void displayAd() {
         log.d("displayAd");
         if (videoPlayerWithAdPlayback != null && videoPlayerWithAdPlayback.getAdPlayerView() != null) {
@@ -1285,8 +1209,6 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         switch (adEvent.getType()) {
             case LOADED:
                 adInfo = createAdInfo(adEvent.getAd());
-                log.e("Gourav => adInfo.getAdPositionType() "+ adInfo.getAdPositionType() + " adInfo.getAdIndexInPod() " + adInfo.getAdIndexInPod() + " adInfo.getPodIndex() " + adInfo.getPodIndex() + " adInfo.getPodCount() " + adInfo.getPodCount() + " adInfo.getTotalAdsInPod() " + adInfo.getTotalAdsInPod() + " adInfo.isBumper() " + adInfo.isBumper());
-                log.e("Gourav => adInfo.getAdPodTimeOffset() " + adInfo.getAdPodTimeOffset() + " adInfo.getAdPlayHead() " + adInfo.getAdPlayHead());
                 if (appIsInBackground) {
                     appInBackgroundDuringAdLoad = true;
                     if (adsManager != null) {
@@ -1522,7 +1444,6 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                 messageBus.post(new AdEvent(AdEvent.Type.ICON_TAPPED));
                 break;
             case AD_BREAK_READY:
-                log.d("AD_BREAK_READY");
                 if (adsManager != null) {
                     adsManager.start();
                 }

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -1265,11 +1265,11 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         }
         AdEvent.Error errorEvent = new AdEvent.Error(new PKError(errorCategory, errorType, adErrorSeverity, message, exception));
 
-        if (getIMAEventsListener() != null) {
+        if (isAdvertisingConfigured && getIMAEventsListener() != null) {
             imaEventsListener.adError(errorEvent);
+        } else {
+            messageBus.post(errorEvent);
         }
-
-        messageBus.post(errorEvent);
     }
 
     @Override

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -637,6 +637,10 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
             return;
         }
 
+        if (sdkFactory == null) {
+            return;
+        }
+
         // Create the ads request.
         final AdsRequest request = sdkFactory.createAdsRequest();
         if (TextUtils.isEmpty(adTagUrl)) {
@@ -645,7 +649,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
             request.setAdTagUrl(adTagUrl);
         }
 
-        if (adConfig.getAdLoadTimeOut() > 0 && adConfig.getAdLoadTimeOut() < Consts.MILLISECONDS_MULTIPLIER && adConfig.getAdLoadTimeOut() != IMAConfig.DEFAULT_AD_LOAD_TIMEOUT) {
+        if (adConfig != null && adConfig.getAdLoadTimeOut() > 0 && adConfig.getAdLoadTimeOut() < Consts.MILLISECONDS_MULTIPLIER && adConfig.getAdLoadTimeOut() != IMAConfig.DEFAULT_AD_LOAD_TIMEOUT) {
             request.setVastLoadTimeout(adConfig.getAdLoadTimeOut() * Consts.MILLISECONDS_MULTIPLIER);
         }
         if (videoPlayerWithAdPlayback != null) {

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,4 @@
 jdk:
-  - oraclejdk8 
+   - openjdk11
 before_install:
    - curl https://kaltura.github.io/fe-tools/android/license.sh | sh

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -2,3 +2,4 @@ jdk:
    - openjdk11
 before_install:
    - curl https://kaltura.github.io/fe-tools/android/license.sh | sh
+


### PR DESCRIPTION
### Description of the Changes

[Works with [Kaltura-Player](https://github.com/kaltura/kaltura-player-android)]

With Ad layout config you can create your own ad break timeline using your vast tags. Ad break can be set as pre, mid and post rolls and each ad break can contain a single vast tag or multiple tags, either as a pod, but also as a Waterfall.

