### PR TITLE
FEC-12227 Ability to give surface aspect ratio for the Ads

### DIFF
--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/ExoPlayerWithAdPlayback.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/ExoPlayerWithAdPlayback.java
@@ -613,7 +613,7 @@ public class ExoPlayerWithAdPlayback extends RelativeLayout implements Player.Li
         adPlayer.setVolume(volume);
     }
 
-    public void setSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode, boolean isUpdateResizeMode) {
+    public void setSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode) {
         if (resizeMode == null) {
             return;
         }

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/ExoPlayerWithAdPlayback.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/ExoPlayerWithAdPlayback.java
@@ -39,6 +39,7 @@ import com.kaltura.playkit.PKLog;
 import com.kaltura.playkit.PKMediaFormat;
 import com.kaltura.playkit.PlayerState;
 import com.kaltura.playkit.player.MediaSupport;
+import com.kaltura.playkit.player.PKAspectRatioResizeMode;
 import com.kaltura.playkit.plugins.ads.AdCuePoints;
 import com.kaltura.playkit.utils.Consts;
 
@@ -114,6 +115,8 @@ public class ExoPlayerWithAdPlayback extends RelativeLayout implements Player.Li
         void adFirstPlayStarted();
 
         void adPlaybackInfoUpdated(int width, int height, int bitrate);
+
+        void onSurfaceAspectRatioChanged(PKAspectRatioResizeMode resizeMode);
     }
 
     public ExoPlayerWithAdPlayback(Context context, AttributeSet attrs, int defStyle) {
@@ -375,7 +378,7 @@ public class ExoPlayerWithAdPlayback extends RelativeLayout implements Player.Li
     @Override
     public void videoFormatChanged(Format trackFormat) {
         log.d("videoFormatChanged " + trackFormat);
-        if (trackFormat != null) {
+        if (trackFormat != null && onAdPlayBackListener != null) {
             onAdPlayBackListener.adPlaybackInfoUpdated(trackFormat.width, trackFormat.height, trackFormat.bitrate);
         }
     }
@@ -610,6 +613,20 @@ public class ExoPlayerWithAdPlayback extends RelativeLayout implements Player.Li
             return;
         }
         adPlayer.setVolume(volume);
+    }
+
+    public void setSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode, boolean isUpdateResizeMode) {
+        if (resizeMode == null) {
+            return;
+        }
+        if (adVideoPlayerView != null && onAdPlayBackListener != null) {
+            log.d("Ad surfaceAspectRatioResizeMode: " + resizeMode.name());
+            adVideoPlayerView.setResizeMode(PKAspectRatioResizeMode.getExoPlayerAspectRatioResizeMode(resizeMode));
+            // Don't take this condition outside because we don't want to send this event if listener is null
+            if (isUpdateResizeMode) {
+                onAdPlayBackListener.onSurfaceAspectRatioChanged(resizeMode);
+            }
+        }
     }
 
     private void initializePlayer(String adUrl, boolean adShouldAutoPlay) {

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/ExoPlayerWithAdPlayback.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/ExoPlayerWithAdPlayback.java
@@ -115,8 +115,6 @@ public class ExoPlayerWithAdPlayback extends RelativeLayout implements Player.Li
         void adFirstPlayStarted();
 
         void adPlaybackInfoUpdated(int width, int height, int bitrate);
-
-        void onSurfaceAspectRatioChanged(PKAspectRatioResizeMode resizeMode);
     }
 
     public ExoPlayerWithAdPlayback(Context context, AttributeSet attrs, int defStyle) {
@@ -619,13 +617,9 @@ public class ExoPlayerWithAdPlayback extends RelativeLayout implements Player.Li
         if (resizeMode == null) {
             return;
         }
-        if (adVideoPlayerView != null && onAdPlayBackListener != null) {
+        if (adVideoPlayerView != null) {
             log.d("Ad surfaceAspectRatioResizeMode: " + resizeMode.name());
             adVideoPlayerView.setResizeMode(PKAspectRatioResizeMode.getExoPlayerAspectRatioResizeMode(resizeMode));
-            // Don't take this condition outside because we don't want to send this event if listener is null
-            if (isUpdateResizeMode) {
-                onAdPlayBackListener.onSurfaceAspectRatioChanged(resizeMode);
-            }
         }
     }
 

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -290,7 +290,6 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         requestAdsOnUpdateMedia(adConfig.getAdTagUrl());
     }
 
-    
     private AdDisplayContainer createAdDisplayContainer() {
         if (adCompanionViewGroup != null) {
             adCompanionViewGroup.removeAllViews();

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -57,6 +57,7 @@ import com.kaltura.playkit.ads.PKAdInfo;
 import com.kaltura.playkit.ads.PKAdPluginType;
 import com.kaltura.playkit.ads.PKAdProviderListener;
 import com.kaltura.playkit.ads.PKAdvertisingAdInfo;
+import com.kaltura.playkit.player.PKAspectRatioResizeMode;
 import com.kaltura.playkit.player.PlayerEngine;
 import com.kaltura.playkit.player.PlayerSettings;
 import com.kaltura.playkit.plugin.ima.BuildConfig;
@@ -681,6 +682,12 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         }
         if (videoPlayerWithAdPlayback != null) {
             request.setContentProgressProvider(videoPlayerWithAdPlayback.getContentProgressProvider());
+            if (player != null &&
+                    player.getSettings() != null &&
+                    player.getSettings() instanceof PlayerSettings &&
+                    ((PlayerSettings)player.getSettings()).getAspectRatioResizeMode() != null) {
+                videoPlayerWithAdPlayback.setSurfaceAspectRatioResizeMode(((PlayerSettings)player.getSettings()).getAspectRatioResizeMode(), false);
+            }
         }
 
         if (adConfig != null) {
@@ -817,6 +824,13 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     public void setVolume(float volume) {
         if (videoPlayerWithAdPlayback != null) {
             videoPlayerWithAdPlayback.setVolume(volume);
+        }
+    }
+
+    @Override
+    public void updateSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode) {
+        if (videoPlayerWithAdPlayback != null && resizeMode != null) {
+            videoPlayerWithAdPlayback.setSurfaceAspectRatioResizeMode(resizeMode, true);
         }
     }
 
@@ -1822,6 +1836,14 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
             adInfo.setMediaBitrate(bitrate);
         }
         messageBus.post(new AdEvent.AdPlaybackInfoUpdated(width, height, bitrate));
+    }
+
+    @Override
+    public void onSurfaceAspectRatioChanged(PKAspectRatioResizeMode resizeMode) {
+        log.d("AD onSurfaceAspectRatioChanged");
+        if (resizeMode != null) {
+            messageBus.post(new AdEvent.AdSurfaceAspectRatioResizeModeChanged(resizeMode));
+        }
     }
 
     private Map<com.google.ads.interactivemedia.v3.api.AdEvent.AdEventType, AdEvent.Type> buildAdsEventMap() {

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -686,7 +686,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
                     player.getSettings() != null &&
                     player.getSettings() instanceof PlayerSettings &&
                     ((PlayerSettings)player.getSettings()).getAspectRatioResizeMode() != null) {
-                videoPlayerWithAdPlayback.setSurfaceAspectRatioResizeMode(((PlayerSettings)player.getSettings()).getAspectRatioResizeMode(), false);
+                videoPlayerWithAdPlayback.setSurfaceAspectRatioResizeMode(((PlayerSettings)player.getSettings()).getAspectRatioResizeMode());
             }
         }
 
@@ -830,7 +830,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
     @Override
     public void updateSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode resizeMode) {
         if (videoPlayerWithAdPlayback != null && resizeMode != null) {
-            videoPlayerWithAdPlayback.setSurfaceAspectRatioResizeMode(resizeMode, true);
+            videoPlayerWithAdPlayback.setSurfaceAspectRatioResizeMode(resizeMode);
         }
     }
 

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -1838,14 +1838,6 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         messageBus.post(new AdEvent.AdPlaybackInfoUpdated(width, height, bitrate));
     }
 
-    @Override
-    public void onSurfaceAspectRatioChanged(PKAspectRatioResizeMode resizeMode) {
-        log.d("AD onSurfaceAspectRatioChanged");
-        if (resizeMode != null) {
-            messageBus.post(new AdEvent.AdSurfaceAspectRatioResizeModeChanged(resizeMode));
-        }
-    }
-
     private Map<com.google.ads.interactivemedia.v3.api.AdEvent.AdEventType, AdEvent.Type> buildAdsEventMap() {
         adEventsMap = new HashMap<>();
         adEventsMap.put(com.google.ads.interactivemedia.v3.api.AdEvent.AdEventType.ALL_ADS_COMPLETED, AdEvent.Type.ALL_ADS_COMPLETED);

--- a/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
+++ b/imaplugin/src/main/java/com/kaltura/playkit/plugins/ima/IMAPlugin.java
@@ -290,6 +290,7 @@ public class IMAPlugin extends PKPlugin implements AdsProvider, com.google.ads.i
         requestAdsOnUpdateMedia(adConfig.getAdTagUrl());
     }
 
+    
     private AdDisplayContainer createAdDisplayContainer() {
         if (adCompanionViewGroup != null) {
             adCompanionViewGroup.removeAllViews();


### PR DESCRIPTION
Aspect ratio passed for the Content will be applied same for the Ad's view.

To set the resize mode,

```java
player.getSettings().setSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode.zoom);
```
To update the resize mode,

```java
player.updateSurfaceAspectRatioResizeMode(PKAspectRatioResizeMode.fit);
```